### PR TITLE
Allow for specifying set timeout.

### DIFF
--- a/ipsetpy/wrapper.py
+++ b/ipsetpy/wrapper.py
@@ -117,8 +117,11 @@ def ipset_send_command_g(*arguments, **kv_arguments):
         _process_error_message(error)
 
 
-def ipset_create_set(set_name, type_name, exist=False, command_timeout=None):
+def ipset_create_set(set_name, type_name, entry_timeout=False, exist=False, command_timeout=None):
     arguments = ["create", set_name, type_name]
+    if entry_timeout:
+        arguments.append("timeout")
+        arguments.append("%d" % (int(entry_timeout),))
     if exist:
         arguments.append('-exist')
     return ipset_send_command(*arguments, command_timeout=command_timeout)


### PR DESCRIPTION
Allow for set-based timeout values. From the ipset man page:

```
GENERIC CREATE AND ADD OPTIONS
   timeout
       All set types supports the optional timeout parameter when creating a set and adding entries. The value of the timeout parameter for the create command
       means  the  default  timeout  value (in seconds) for new entries. If a set is created with timeout support, then the same timeout option can be used to
       specify non-default timeout values when adding entries. Zero timeout value means the entry is added permanent to the set.  The timeout value of already
       added elements can be changed by readding the element using the -exist option. Example:

              ipset create test hash:ip timeout 300

              ipset add test 192.168.0.1 timeout 60

              ipset -exist add test 192.168.0.1 timeout 600
```
