### PR TITLE
Support maxelem and range in set creation.

### DIFF
--- a/ipsetpy/wrapper.py
+++ b/ipsetpy/wrapper.py
@@ -117,8 +117,15 @@ def ipset_send_command_g(*arguments, **kv_arguments):
         _process_error_message(error)
 
 
-def ipset_create_set(set_name, type_name, entry_timeout=None, exist=False, command_timeout=None):
+def ipset_create_set(set_name, type_name, entry_timeout=None, maxelem=None, set_range=None, 
+                     exist=False, command_timeout=None):
     arguments = ["create", set_name, type_name]
+    if set_range:
+        arguments.append("range")
+        arguments.append("%s" % set_range)
+    if maxelem:
+        arguments.append("maxelem")
+        arguments.append("%d" % (int(maxelem),))
     if entry_timeout:
         arguments.append("timeout")
         arguments.append("%d" % (int(entry_timeout),))


### PR DESCRIPTION
Allow specifying range (for bitmap:* set type) and maxelem (for hash:* set types) on set creation.